### PR TITLE
Add deployment helper

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# Ignore media directory and database (for portability)
+
+media
+static
+db.sqlite3
+deployment

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@ db.sqlite3
 .vscode/
 SAGTA-Workspace.code-workspace
 __*
+.python-version
+
+
+.env
+.idea
+docker-compose.override.yml
+nginx.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ LABEL maintainer="hello@wagtail.io"
 
 # Set environment varibles
 ENV PYTHONUNBUFFERED 1
-ENV DJANGO_ENV dev
 
 COPY ./requirements.txt /code/requirements.txt
 RUN pip install --upgrade pip
@@ -17,11 +16,14 @@ COPY . /code/
 # Set the working directory to /code/
 WORKDIR /code/
 
-RUN python manage.py migrate
-
 RUN useradd wagtail
 RUN chown -R wagtail /code
 USER wagtail
 
-EXPOSE 8000
-CMD exec gunicorn mysite.wsgi:application --bind 0.0.0.0:8000 --workers 3
+ENV UWSGI_PORT 8000
+
+EXPOSE ${UWSGI_PORT}
+ENTRYPOINT ["/code/entrypoint.sh"]
+
+
+CMD gunicorn mysite.wsgi:application --bind 0.0.0.0:${UWSGI_PORT} --workers 3

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# README
+
+Run the site locally for development
+
+For production deployment configuration, refer to [Deployment README](deployment/README.md)
+
+## Prerequisites
+
+- Python 3
+
+## Quick Start Guide
+
+Assuming root directory is the repo directory for every start of the scripts sections.
+
+Create a virtual environment for development purposes
+
+```shell script
+virtualenv env
+source env/bin/activate
+```
+
+Install dependencies for development
+
+```shell script
+pip install -r requirements.txt -r requirements.dev.txt
+```
+
+Run initial manage.py command
+
+```shell script
+./manage.py migrate
+./manage.py collectstatic
+```
+
+Start Django web development server
+
+```shell script
+./manage.py runserver 0.0.0.0:8080
+```
+
+Web development server will available at http://localhost:8080

--- a/deployment/.env.dev.example
+++ b/deployment/.env.dev.example
@@ -1,0 +1,5 @@
+COMPOSE_PROJECT_NAME=sagtaweb
+DJANGO_SETTINGS_MODULE=mysite.settings.dev
+DEBUG=True
+SITE_NAME=sagtawebsite.test
+HTTP_PORT=8080

--- a/deployment/.env.prod.example
+++ b/deployment/.env.prod.example
@@ -1,0 +1,6 @@
+COMPOSE_PROJECT_NAME=sagtaweb
+DJANGO_SETTINGS_MODULE=mysite.settings.production
+DEBUG=False
+SITE_NAME=sagtawebsite.test
+HTTP_PORT=8080
+SECRET_KEY="somerandomstring"

--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -1,0 +1,15 @@
+
+build:
+	@docker-compose build
+
+pull:
+	@docker-compose pull
+
+up:
+	@docker-compose up -d nginx
+
+down:
+	@docker-compose down
+
+ps:
+	@docker-compose ps

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,107 @@
+# Deployment README
+
+This is a guide to start deployment configuration for production instance using docker and docker-compose.
+
+## Prerequisite
+
+- Docker Engine
+- Resolvable FQDN to be used as SITE_NAME
+
+## Quick Start Guide
+
+These steps will deploy production server on a host with docker installed.
+Every shell script command is assumed to start from this `deployment` directory.
+
+### Create configurations
+
+Create a copy of docker-compose environment file:
+
+```shell script
+cp .env.prod.example .env
+```
+
+Modify the settings inside `.env` file to reflect production configurations.
+Change `SITE_NAME` and `HTTP_PORT` to reflect real FQDN name and port that 
+the server will host (if it is under load balancer/reverse proxy).
+For a production site, generate a random string for `SECRET_KEY` value.
+
+Create a copy of nginx config file:
+
+```shell script
+cp nginx.prod.conf nginx.conf
+```
+
+Modify nginx configuration inside `nginx.conf` file to reflect nginx reverse proxy 
+settings.
+Nginx is used to reverse proxy `SITE_NAME` into `uwsgi` container that runs gunicorn.
+Nginx is also used to serve file based requests directly like static and media folder.
+Change the `server_name` directive to reflect the FQDN or IP Address that is going to be used.
+
+Create a copy of docker-compose.override.yml file:
+
+```shell script
+cp docker-compose.override.sample.yml docker-compose.override.yml
+```
+
+This file is used to easily modify docker-compose configuration if you need it.
+
+### Preparing docker image
+
+Build the image if you haven't already, or alternatively, pull the image from image registry.
+Pick either one.
+
+#### Building the image directly
+
+Run make build
+
+```shell script
+make build
+```
+
+This will build the image and tag it locally as sagtaweb:latest.
+You may want to tag it as different version (for history versioning) like this:
+
+```shell script
+docker tag sagtaweb:latest sagtaweb:<YY.MM.DD>
+```
+
+With <YY.MM.DD> replaced by current year, month, and date, like this: 20.04.18
+That way, even if you rebuild you will have previous tag (locally) in the machine.
+
+#### Pulling the image from registry
+
+If you pull the image from docker image registry, then you don't need to build.
+Modify `docker-compose.override.yml` like this:
+
+```yaml
+version: '3.7'
+services:
+  uwsgi:
+    image: <DOCKER_HUB_USER_NAME>/<REPO_NAME>:<TAG_NAME>
+```
+
+Note, that we deleted `build` key because we don't want to build the image.
+Change `<DOCKER_HUB_USER_NAME>/<REPO_NAME>:<TAG_NAME>` with the full name of the image version.
+It will be something along like this: `wolfbyne/sagtaweb:20.04.18`
+
+Then run:
+
+```shell script
+make pull
+```
+
+### Running the service
+
+To run the service:
+
+```shell script
+make up
+```
+
+To shut it down, run:
+
+```shell script
+make down
+```
+
+

--- a/deployment/docker-compose.override.sample.yml
+++ b/deployment/docker-compose.override.sample.yml
@@ -1,0 +1,7 @@
+version: '3.7'
+services:
+  uwsgi:
+    image: sagtaweb:latest
+    build:
+      context: ../
+      dockerfile: Dockerfile

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.7'
+services:
+  wsgi:
+    image: sagtaweb:latest
+    environment:
+      DJANGO_SETTINGS_MODULE: "${DJANGO_SETTINGS_MODULE}"
+      DEBUG: "${DEBUG}"
+      SITE_NAME: "${SITE_NAME}"
+      UWSGI_PORT: "8000"
+      SECRET_KEY: "${SECRET_KEY}"
+    volumes:
+      # Will also mount media, static, and sqlite db in that directory
+      - ../:/code/
+
+  nginx:
+    image: nginx
+    # let uwsgi online first
+    depends_on:
+      - wsgi
+    volumes:
+      # mount config file directly
+      - ./nginx.conf:/etc/nginx/conf.d/mysite.conf
+      # mount only media and static to serve directly from nginx
+      - ../media:/opt/sagtawebsite/media
+      - ../static:/opt/sagtawebsite/static
+    ports:
+      - "${HTTP_PORT}:80"

--- a/deployment/nginx.prod.conf
+++ b/deployment/nginx.prod.conf
@@ -1,0 +1,47 @@
+# mysite_nginx.conf
+
+# the upstream component nginx needs to connect to
+upstream django {
+    server wsgi:8000;
+}
+
+server {
+    # if no Host match, close the connection to prevent host spoofing
+    listen 80 default_server;
+    return 444;
+}
+
+# configuration of the server
+server {
+    # the port your site will be served on
+    listen      80;
+    # the domain name it will serve for
+    server_name sagtawebsite.test; # substitute your machine's IP address or FQDN
+    charset     utf-8;
+
+    # max upload size
+    client_max_body_size 75M;   # adjust to taste
+
+    # Django media
+    location /media  {
+        alias /opt/sagtawebsite/media;  # your Django project's media files - amend as required
+    }
+
+    location /static {
+        alias /opt/sagtawebsite/static; # your Django project's static files - amend as required
+    }
+
+    # Finally, send all non-media requests to the Django server.
+    location / {
+        set $upstream django;
+
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $http_host;
+        # we don't want nginx trying to do something clever with
+        # redirects, we set the Host: header above already.
+        proxy_redirect off;
+        proxy_pass http://$upstream;
+    }
+
+}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+# Run migrate and collectstatic
+./manage.py migrate --noinput
+./manage.py collectstatic --noinput
+
+exec "$@"

--- a/mysite/settings/production.py
+++ b/mysite/settings/production.py
@@ -1,6 +1,12 @@
 from .base import *
+import ast
 
-DEBUG = False
+SECRET_KEY = os.environ.get('SECRET_KEY')
+DEBUG = ast.literal_eval(os.environ.get('DEBUG', 'False'))
+WAGTAIL_SITE_NAME = os.environ.get('SITE_NAME')
+HTTP_PORT = os.environ.get('HTTP_PORT')
+ALLOWED_HOSTS = [
+    '{}'.format(WAGTAIL_SITE_NAME), 'www.{}'.format(WAGTAIL_SITE_NAME)]
 
 try:
     from .local import *

--- a/mysite/urls.py
+++ b/mysite/urls.py
@@ -22,18 +22,18 @@ urlpatterns = [
 ]
 
 
-if settings.DEBUG:
-    from django.conf.urls.static import static
-    from django.contrib.staticfiles.urls import staticfiles_urlpatterns
-
-    # Serve static and media files from development server
-    urlpatterns += staticfiles_urlpatterns()
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-
-    import debug_toolbar
-    urlpatterns = [
-        path('__debug__/', include(debug_toolbar.urls)),
-    ] + urlpatterns
+# if settings.DEBUG:
+#     from django.conf.urls.static import static
+#     from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+#
+#     # Serve static and media files from development server
+#     urlpatterns += staticfiles_urlpatterns()
+#     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+#
+#     import debug_toolbar
+#     urlpatterns = [
+#         path('__debug__/', include(debug_toolbar.urls)),
+#     ] + urlpatterns
 
 urlpatterns = urlpatterns + [
     # For anything not caught by a more specific rule above, hand over to

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,0 +1,1 @@
+django-debug-toolbar==2.2


### PR DESCRIPTION
Hi @wolfbyne ,

This is the changes to help deploy to production using docker.

The production architecture is a combination of the app + nginx.
The app is handled by Gunicorn as recommended by wagtail, but we add file based request handling on top of it, using nginx proxy.

You can try this setup first. I've provided a README for the repo and in the `deployment` directory.
See if the README is easily understood or not.